### PR TITLE
#23 Add voltage monitor channels (ch1-ch4) to sis_bias_reader config

### DIFF
--- a/tz_controller/device_config.toml
+++ b/tz_controller/device_config.toml
@@ -12,10 +12,12 @@ tuned = { v1 = 6.9, h1 = 6.5, v2 = 6.5, h2 = 7.4}
 [sis_bias_reader]
 _ = "CPZ3177"
 rsw_id = 0
-all_ch_num = 4
-channel = { v1 = "ch5", v2 = "ch8", h1 = "ch6", h2 = "ch7"}
-ch_range = { v1 = "10V", h1 = "10V", h2 = "10V", v2 = "10V" }
-ch_num_li = [5,6,7,8]
+all_ch_num = 8
+channel = { v1 = "ch5", v2 = "ch8", h1 = "ch6", h2 = "ch7",
+            v1_v = "ch1", v2_v = "ch4", h1_v = "ch2", h2_v = "ch3"}
+ch_range = { v1 = "10V", v2 = "10V", h1 = "10V", h2 = "10V",
+             v1_v = "10V", v2_v = "10V", h1_v = "10V", h2_v = "10V"}
+ch_num_li = [1,2,3,4,5,6,7,8]
 ave_num = 10
 smpl_freq = 1000
 smpl_num = 15


### PR DESCRIPTION
Background:
- sis_bias_reader (CPZ-3177) was configured with only ch5-ch8 (current monitor).
- ch1-ch4 (voltage monitor) were missing, making it impossible to read actual junction voltage for IV curve measurement.

Changes:
- Added voltage monitor channels (v1_v, h1_v, h2_v, v2_v) mapped to ch1-ch4.
- Updated ch_range and all_ch_num accordingly.

Basis for ch1-ch4 assignment:
- Inferred from sis_iv_sim.py (legacy code) and symmetry with current channel assignment (ch5-ch8), assuming the same ordering after hardware reconfiguration.
- Needs verification on the actual system.

Note:
- smpl_num may need adjustment after channel count increase (4→8). To be verified during testing.

**Checks**

- [ ] Debugging completed
- [x] Please debug me

**Related Issue**

This PR closes #23 .

